### PR TITLE
Updated Dockerfile-1.9

### DIFF
--- a/Dockerfile-1.9
+++ b/Dockerfile-1.9
@@ -3,7 +3,7 @@
 # supported go repos.
 # ./run_tests.sh 1.9
 
-FROM golang:1.9
+FROM golang:1.9.4
 
 LABEL description="Decred golang builder image"
 LABEL version="1.0"
@@ -39,9 +39,9 @@ USER $USER
 ENV HOME /home/$USER
 
 #Get deps
-ENV DEP_TAG v0.3.1
-ENV GLIDE_TAG v0.12.3
-ENV GOMETALINTER_TAG v1.2.1
+ENV DEP_TAG v0.4.1
+ENV GLIDE_TAG v0.13.1
+ENV GOMETALINTER_TAG v2.0.5
 
 WORKDIR /go/src
 RUN go get -v github.com/Masterminds/glide && \


### PR DESCRIPTION
Created Dockerfile-1.9 to match version from decred/dcrd. This is groundwork so that dockerhub image for 1.9 can be built from decred/dcrdocker instead of decred/dcrd, as it appears to currently be doing. After this is done, I'd like to remove the Dockerfile-1.9 from decred/dcrd.

This will also need someone to update the dockerhub build settings to build from this repo and Dockerfile.