### PR TITLE
Add curl to images

### DIFF
--- a/Dockerfile-1.10
+++ b/Dockerfile-1.10
@@ -19,7 +19,7 @@ RUN adduser --disabled-password --gecos ''  $USER
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
-    apt-get install -qy rsync git xz-utils
+    apt-get install -qy rsync git xz-utils curl
 
 # create directory for build artifacts, adjust user permissions
 RUN mkdir /release && \

--- a/Dockerfile-1.11
+++ b/Dockerfile-1.11
@@ -19,7 +19,7 @@ RUN adduser --disabled-password --gecos ''  $USER
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
-    apt-get install -qy rsync git xz-utils
+    apt-get install -qy rsync git xz-utils curl
 
 # create directory for build artifacts, adjust user permissions
 RUN mkdir /release && \

--- a/Dockerfile-dcrd
+++ b/Dockerfile-dcrd
@@ -21,9 +21,9 @@ RUN set -x && \
 
     # Update base distro & install build tooling
     DEBIAN_FRONTEND=noninteractive && \
-    BUILD_DEPS=curl && \
+    BUILD_DEPS="" && \
     apt-get update && \
-    apt-get install -qy $BUILD_DEPS && \
+    apt-get install -qy curl $BUILD_DEPS && \
 
     # Decred release url and files
     DCR_RELEASE_URL="https://github.com/decred/decred-binaries/releases/download/$DCR_RELEASE" && \


### PR DESCRIPTION
Previously the dcrd image removed curl as part of the cleanup step.
However, curl is needed in order to run health checks to ensure the
service is up and running correctly using the HEALTHCHECK feature
of docker.