### PR TITLE
add golangci-lint to Dockerfile-1.11

### DIFF
--- a/Dockerfile-1.11
+++ b/Dockerfile-1.11
@@ -18,20 +18,8 @@ RUN adduser --disabled-password --gecos ''  $USER
 # update base distro & install build tooling
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && apt-get install -qy apt-transport-https ca-certificates
-
-ENV NODE_VERSION node_11.x
-
-RUN curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-    DISTRO=`grep VERSION= /etc/os-release | awk -F"[()]" '{print $2}'` && \
-    echo "deb https://deb.nodesource.com/$NODE_VERSION $DISTRO main" | tee /etc/apt/sources.list.d/nodesource.list && \
-    echo "deb-src https://deb.nodesource.com/$NODE_VERSION $DISTRO main" | tee -a /etc/apt/sources.list.d/nodesource.list
-
 RUN apt-get update && \
-    apt-get install -qy rsync git xz-utils apt-utils nodejs && \
-    echo Node.js: `node --version`
-
-RUN npm install stylelint stylelint-config-standard eslint -g
+    apt-get install -qy rsync git xz-utils
 
 # create directory for build artifacts, adjust user permissions
 RUN mkdir /release && \

--- a/Dockerfile-1.11
+++ b/Dockerfile-1.11
@@ -3,10 +3,10 @@
 # supported go repos.
 # ./run_tests.sh 1.11
 
-FROM golang:1.11
+FROM golang:1.11.2
 
 LABEL description="Decred golang builder image"
-LABEL version="1.0"
+LABEL version="1.1"
 LABEL maintainer "dhill@mindcry.org"
 
 ENV TERM linux
@@ -18,8 +18,20 @@ RUN adduser --disabled-password --gecos ''  $USER
 # update base distro & install build tooling
 ENV DEBIAN_FRONTEND noninteractive
 
+RUN apt-get update && apt-get install -qy apt-transport-https ca-certificates
+
+ENV NODE_VERSION node_11.x
+
+RUN curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+    DISTRO=`grep VERSION= /etc/os-release | awk -F"[()]" '{print $2}'` && \
+    echo "deb https://deb.nodesource.com/$NODE_VERSION $DISTRO main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    echo "deb-src https://deb.nodesource.com/$NODE_VERSION $DISTRO main" | tee -a /etc/apt/sources.list.d/nodesource.list
+
 RUN apt-get update && \
-    apt-get install -qy rsync git xz-utils
+    apt-get install -qy rsync git xz-utils apt-utils nodejs && \
+    echo Node.js: `node --version`
+
+RUN npm install stylelint stylelint-config-standard eslint -g
 
 # create directory for build artifacts, adjust user permissions
 RUN mkdir /release && \
@@ -39,9 +51,13 @@ ENV HOME /home/$USER
 #Get deps
 ENV DEP_TAG v0.4.1
 ENV GOMETALINTER_TAG v2.0.5
+ENV GOLANGCI_TAG v1.12.3
 
 WORKDIR /go/src
-RUN go get -v github.com/alecthomas/gometalinter && \
+    RUN git clone --branch $GOLANGCI_TAG https://github.com/golangci/golangci-lint && \
+    cd golangci-lint/cmd/golangci-lint && \
+    GO111MODULE=on go install && \
+    go get -v github.com/alecthomas/gometalinter && \
     cd /go/src/github.com/alecthomas/gometalinter && \
     git checkout $GOMETALINTER_TAG && \
     go install -i && \

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ Dockerfiles for Decred.
 
 ## General info
 
-This repo contains a number of docker files used by decred for various purposes.
+This repository contains a number of docker files used by decred for various purposes.
 
-The main goal is to keep the images simple and understandable.  Although we would like to keep images small when possible, simplicity/readability is to be preferred over size in all cases.  For example, this means it is better to use env variables for settings to be in one place even if it requires more than one `RUN` directive in the Dockerfile.  Whenever possible images should import from each other so we have as close to a known base as possible.  When possible, the images strive to be self-contained with as much data as possible set at build time (and persistant data mounted from host only).
+The main goal is to keep the images simple and understandable.  Although we would like to keep images small when possible, simplicity/readability is to be preferred over size in all cases.  For example, this means it is better to use env variables for settings to be in one place even if it requires more than one `RUN` directive in the Dockerfile.  Whenever possible images should import from each other so we have as close to a known base as possible.  When possible, the images strive to be self-contained with as much data as possible set at build time (and persistent data mounted from host only).
 
 ## Available Images
 
 The table below gives link to all images but a brief description is useful first.  There is a mainnet and testnet dcrd image with no special settings (these can be set with a local dcrd.conf file).  There are also images based on those that have the settings needed for insight already included.  Mainnet and a testnet insight images are provided and are meant to be run on the same machine as the dcrd image they use for blockchain data.
 
-Images for running a full build and test of dcrd, dcrwallet, or any of the go projects are provided.  These are generally run in travis but this way the setup can be run identically locally and from travis.  Unlike the other images which are based on a recent Ubuntu, these are based on the offical go images.  They must be modified if a new minor version of go is needed and a new one added for a new major version.  Both opperations are described below.
+Images for running a full build and test of dcrd, dcrwallet, or any of the go projects are provided.  These are generally run in travis but this way the setup can be run identically locally and from travis.  Unlike the other images which are based on a recent Ubuntu, these are based on the official go images.  They must be modified if a new minor version of go is needed and a new one added for a new major version.  Both operations are described below.
 
-The decrediton builder image allows us to check the build and lint in travis and allows for an easy build during development although we do not use the artifacts it creats for releases.  It would be a nice improvement if the node/npm dependancies could be included in the built image (would speed up builds and make them more reproducable).  It is possible something like npm-cache-install could be useful there.
+The decrediton builder image allows us to check the build and lint in travis and allows for an easy build during development although we do not use the artifacts it creates for releases.  It would be a nice improvement if the node/npm dependencies could be included in the built image (would speed up builds and make them more reproducible).  It is possible something like npm-cache-install could be useful there.
 
 
 | Dockerfile | Image Name | Link | Description | pull command |
@@ -33,7 +33,8 @@ The decrediton builder image allows us to check the build and lint in travis and
 ## Building images
 
 The images are built and pushed to the docker hub repo as follows (the names can be taken from the table above):
-```
+
+```sh
 DOCKER_IMAGE_TAG=dcrd-mainnet
 docker build -t $DOCKER_IMAGE_TAG -f Dockerfile-dcrd .
 docker tag $DOCKER_IMAGE_TAG decred/$DOCKER_IMAGE_TAG
@@ -43,20 +44,21 @@ docker push decred/$DOCKER_IMAGE_TAG
 ## Using the images
 
 All of the images have usage instructions at the top of the dockerfile.  Just pull the image:
-```
+
+```sh
 docker pull decred/$DOCKER_IMAGE_TAG
 ```
+
 then follow the instructions in the dockerfile.  When necessary, a script to run it is included in the repo where it is needed.
 
 ### Updating docker go versions
 
 When a new minor version of go is released, the docker images must be updated and rebuilt to support it.  For example, when go1.8.3 was released, the file `Dockerfile-1.8` was edited by changing `FROM golang:1.8.2` to `FROM golang:1.8.3`.  Then the image was rebuilt and pushed to docker hub:
-```
+
+```sh
 GOVERSION=1.8
 DOCKER_IMAGE_TAG=decred-golang-builder-$GOVERSION
 docker build -t $DOCKER_IMAGE_TAG -f ./Dockerfile-$GOVERSION .
-docker tag $DOCKER_IMAGE_TAG decred/$DOCKER_IMAGE_TAG
-docker push decred/$DOCKER_IMAGE_TAG
 ```
 
 For a new major version, a new file `Dockerfile-VERSION` must be created and then the previous steps can be followed.  That new version must be added to the travis build matrix to run the tests in travis.


### PR DESCRIPTION
Install golangci-lint v1.12.3.
Bump go version from 1.11 to 1.11.2.
Bump dockerfile version to 1.1.

Resolving https://github.com/decred/dcrdocker/issues/42